### PR TITLE
fix for locked apt package manager

### DIFF
--- a/ansible/roles/ofo/tasks/chromium.yaml
+++ b/ansible/roles/ofo/tasks/chromium.yaml
@@ -7,3 +7,7 @@
       - chromium-browser
     state: present
     update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10

--- a/ansible/roles/ofo/tasks/flatpak_and_qgis.yaml
+++ b/ansible/roles/ofo/tasks/flatpak_and_qgis.yaml
@@ -8,6 +8,10 @@
       - gnome-software-plugin-flatpak
     state: present
     update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
 
 - name: FLATPAK_REMOTE ; add the flathub repo
   become: true

--- a/ansible/roles/ofo/tasks/irods.yaml
+++ b/ansible/roles/ofo/tasks/irods.yaml
@@ -4,6 +4,10 @@
   become: true
   apt:
     deb: http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/{{ LIBSSL_DEB }}
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
 
 - name: APT_KEY ; add the irods key
   become: true
@@ -23,3 +27,7 @@
     name: irods-icommands
     state: present
     update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10

--- a/ansible/roles/ofo/tasks/jupyter.yaml
+++ b/ansible/roles/ofo/tasks/jupyter.yaml
@@ -6,3 +6,7 @@
     pkg:
       - jupyter-notebook
     state: present
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10

--- a/ansible/roles/ofo/tasks/metashape.yaml
+++ b/ansible/roles/ofo/tasks/metashape.yaml
@@ -32,7 +32,11 @@
   apt:
     name: libxcb-xinerama0
     state: present
-
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
+  
 - name: LINEINFILE ; ensure AGISOFT_FLS (floating license server) env var in .profile
   ansible.builtin.lineinfile:
     path: ~/.profile

--- a/ansible/roles/ofo/tasks/qgis.yaml
+++ b/ansible/roles/ofo/tasks/qgis.yaml
@@ -20,3 +20,7 @@
       - qgis-plugin-grass
     state: present
     update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10

--- a/ansible/roles/ofo/tasks/r.yaml
+++ b/ansible/roles/ofo/tasks/r.yaml
@@ -50,11 +50,19 @@
     state: present
     update_cache: yes
     install_recommends: false
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
 
 - name: APT ; install rstudio from remote deb
   become: true
   apt:
     deb: https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2022.12.0-353-amd64.deb
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
 
 - name: LINEINFILE ; ensure RSTUDIO_WHICH_R in .profile
   ansible.builtin.lineinfile:
@@ -76,6 +84,10 @@
       - python3-apt
     state: present
     update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
 
 - name: APT ; install r packages
   become: true
@@ -149,7 +161,11 @@
       -  r-cran-zip
       -  r-cran-zoo
     state: present
-
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
+  
 - name: SHELL ; use Rscript to install bspm
   become: true
   shell: Rscript -e 'install.packages("bspm")'

--- a/ansible/roles/ofo/tasks/ssl.yaml
+++ b/ansible/roles/ofo/tasks/ssl.yaml
@@ -7,7 +7,11 @@
     pkg:
       - nginx
     state: present
-
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10
+  
 - name: FILE ; create nginx ssl directory if it does not exist
   become: true
   ansible.builtin.file:

--- a/ansible/roles/ofo/tasks/sublime.yaml
+++ b/ansible/roles/ofo/tasks/sublime.yaml
@@ -17,3 +17,7 @@
     name: sublime-text
     state: present
     update_cache: yes
+  register: apt_result
+  until: apt_result is not failed
+  retries: 30
+  delay: 10


### PR DESCRIPTION
There are situations when a background process attempts to perform an apt update (i.e. unattended upgrade). This will cause ansible apt module to error. Instead, the safe approach is to wait for the unattended upgrade to finish.

This fix will wait for that moment.