### PR TITLE
Updated resource ignore_changes to prevent unintentional deletion of instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "openstack_compute_instance_v2" "os_instances" {
       error_message = "ERROR: template input image or image_name must be set"
     }
     ignore_changes = [
-      image_id
+      image_id, block_device.0.uuid, name, user_data
     ]
   }
 }


### PR DESCRIPTION
There are situations when the instance resource may be deleted unintentionally for certain instance properties. This PR will prevent these unintentional deletions.