### PR TITLE
pin openstack provider to ~2.1.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack" # "terraform.cyverse.org/cyverse/openstack"
+      version = "~> 2.1.0"
     }
   }
 }


### PR DESCRIPTION
pin openstack provider to ~2.1.0 to work around removal of openstack_compute_floatingip_associate_v2 in v3.0